### PR TITLE
chore: remove deprecated 'smallfiles' flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/circle
     docker:
-      - image: circleci/node:8.5
+      - image: circleci/node:8
     steps:
       - checkout
       - restore_cache:

--- a/samples/replicaset/replicaset.sh
+++ b/samples/replicaset/replicaset.sh
@@ -20,10 +20,10 @@ mkdir -p ./data/data4
 mkdir -p ./log
 
 # Start the replicaset processes.
-mongod --fork --logpath ./log/node1.log --smallfiles --oplogSize 50 --port ${port1} --dbpath ./data/data1 --replSet cluster
-mongod --fork --logpath ./log/node2.log --smallfiles --oplogSize 50 --port ${port2} --dbpath ./data/data2 --replSet cluster
-mongod --fork --logpath ./log/node3.log --smallfiles --oplogSize 50 --port ${port3} --dbpath ./data/data3 --replSet cluster
-mongod --fork --logpath ./log/node4.log --smallfiles --oplogSize 50 --port ${port4} --dbpath ./data/data4 --replSet cluster
+mongod --fork --logpath ./log/node1.log --oplogSize 50 --port ${port1} --dbpath ./data/data1 --replSet cluster
+mongod --fork --logpath ./log/node2.log --oplogSize 50 --port ${port2} --dbpath ./data/data2 --replSet cluster
+mongod --fork --logpath ./log/node3.log --oplogSize 50 --port ${port3} --dbpath ./data/data3 --replSet cluster
+mongod --fork --logpath ./log/node4.log --oplogSize 50 --port ${port4} --dbpath ./data/data4 --replSet cluster
 
 # Wait a bit of time for the process to start.
 sleep 3

--- a/samples/shard/shard.sh
+++ b/samples/shard/shard.sh
@@ -23,9 +23,9 @@ mkdir -p ./data/datars3c
 mkdir -p ./log
 
 # Start the config servers.
-mongod --fork --logpath ./log/cs1.log --smallfiles --oplogSize 50 --port 27117 --dbpath ./data/datacs1 --configsvr --replSet config
-mongod --fork --logpath ./log/cs2.log --smallfiles --oplogSize 50 --port 27118 --dbpath ./data/datacs2 --configsvr --replSet config
-mongod --fork --logpath ./log/cs3.log --smallfiles --oplogSize 50 --port 27119 --dbpath ./data/datacs3 --configsvr --replSet config
+mongod --fork --logpath ./log/cs1.log --oplogSize 50 --port 27117 --dbpath ./data/datacs1 --configsvr --replSet config
+mongod --fork --logpath ./log/cs2.log --oplogSize 50 --port 27118 --dbpath ./data/datacs2 --configsvr --replSet config
+mongod --fork --logpath ./log/cs3.log --oplogSize 50 --port 27119 --dbpath ./data/datacs3 --configsvr --replSet config
 
 # Start the replicasets.
 mongod --fork --replSet rs1 --port 27217 --dbpath ./data/datars1a --logpath ./log/rs1a.log

--- a/samples/standalone/standalone.sh
+++ b/samples/standalone/standalone.sh
@@ -7,7 +7,7 @@ if [[ -d './log' ]]; then rm -rf ./log; fi
 mkdir ./log
 
 # Start the standalone process.
-mongod --fork --logpath ./log/standalone.log --smallfiles --oplogSize 50 --port 27017 --dbpath ./data 
+mongod --fork --logpath ./log/standalone.log --oplogSize 50 --port 27017 --dbpath ./data 
 
 # Wait a bit of time for the process to start.
 sleep 10

--- a/src/mongo-monitor.js
+++ b/src/mongo-monitor.js
@@ -29,6 +29,11 @@ async function checkStatus(params) {
     //  If we don't yet have a client, try and create one. Connection issues
     //  might cause this to fail.
     if (client === null) {
+      //  Note that client *might* have been initialised by the time we hit this
+      //  line, so linting warns us correctly it might already have a value.
+      //  However, overriding the client is fine; it will simply be disposed
+      //  on the next GC cycle.
+      //  eslint-disable-next-line require-atomic-updates
       client = await MongoClient.connect(connectionString.toURI());
 
       Object.keys(eventHandlers).forEach((eventName) => {


### PR DESCRIPTION
This will not work in MongoDB 4 and is deprecated as it relates to the
deprecated MMAPv1 storage engine